### PR TITLE
Add devrel readme content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p>
+  <a href="https://twitter.com/onesignaldevs" target="_blank">
+    <img alt="Twitter: onesignaldevelopers" src="https://img.shields.io/twitter/follow/onesignaldevs?style=social" />
+  </a>
+</p>
+
 # In-app Messaging HTML Templates
 
 HTML Templates for in-app messaging
@@ -27,3 +33,16 @@ For more information of how html in-apps work see our [advanced usage doc](./adv
 ###### [Check List Survey](./check_list_survey)
 
 <img alt="Check List Survey" src="./check_list_survey/readme_assets/checklist_survey_iam.gif" width="200px">
+
+## Show Your Support
+
+Give a :star:️ if this project helped you!
+
+## Join the OneSignal Developers Community
+
+The [OneSignal Developer Community](https://onesignal.com/onesignal-developers) is a group of passionate individuals who work with OneSignal products. Community members have the opportunity to expand their network and knowledge across different technologies.
+
+- Twitter: [@OneSignalDevs](https://twitter.com/onesignal)
+- Github: [@OneSignalDevelopers](https://github.com/OneSignal)
+- Discord: [@onesignal-metabase](https://linkedin.com/company/onesignal)
+


### PR DESCRIPTION
All the OneSignalDevelopers repos need to adhere to our code-sample strategy. This PR adds what's necessary to fulfill that obligation. 

[📝 Rendered Markdown](https://github.com/OneSignalDevelopers/in-app-html-templates/blob/736b58d7e406d237797bf20b2094b144c8b87435/README.md)